### PR TITLE
Update: Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,6 @@
                 "wpackagist-plugin/*",
                 "wpackagist-theme/*"
             ]
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:newshour/wp-core-theme-components.git"
         }
     ],
     "require": {
@@ -30,7 +26,7 @@
         "roots/wp-config": "1.0.0",
         "roots/wp-password-bcrypt": "1.1.0",
         "vlucas/phpdotenv": "^5.3",
-        "newshour/wp-core-theme-components": "^1.0.14",
+        "newshour/wp-core-theme-components": "^1.0.15",
         "wpackagist-plugin/advanced-custom-fields": "^5.10.1",
         "wpackagist-plugin/classic-editor": "^1.0",
         "wpackagist-plugin/debug-bar": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdfa1a57663931c544dbf23918bb7488",
+    "content-hash": "6e5bae43efb27218630e5f244dda1da6",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -288,6 +288,75 @@
                 "source": "https://github.com/doctrine/annotations/tree/1.13.2"
             },
             "time": "2021-08-05T19:00:23+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1958a744696c6bb3bb0d28db2611dc11610e78af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1958a744696c6bb3bb0d28db2611dc11610e78af",
+                "reference": "1958a744696c6bb3bb0d28db2611dc11610e78af",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0",
+                "phpstan/phpstan": "^0.12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.1.5",
+                "vimeo/psalm": "^4.2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
+            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "keywords": [
+                "array",
+                "collections",
+                "iterators",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/collections/issues",
+                "source": "https://github.com/doctrine/collections/tree/1.6.8"
+            },
+            "time": "2021-08-10T18:51:53+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -597,21 +666,22 @@
         },
         {
             "name": "newshour/wp-core-theme-components",
-            "version": "v1.0.14",
+            "version": "v1.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newshour/wp-core-theme-components.git",
-                "reference": "78feb2c6cb096507e04773f967363de8c3dbf5bc"
+                "reference": "96e9f804cc762303710595028a959f013d36e58e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newshour/wp-core-theme-components/zipball/78feb2c6cb096507e04773f967363de8c3dbf5bc",
-                "reference": "78feb2c6cb096507e04773f967363de8c3dbf5bc",
+                "url": "https://api.github.com/repos/newshour/wp-core-theme-components/zipball/96e9f804cc762303710595028a959f013d36e58e",
+                "reference": "96e9f804cc762303710595028a959f013d36e58e",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.4",
                 "doctrine/annotations": "^1.13",
+                "doctrine/collections": "^1.6.8",
                 "nesbot/carbon": "^2.54",
                 "php": ">=7.4",
                 "symfony/asset": "^5.4",
@@ -644,24 +714,16 @@
                     "/Tests/"
                 ]
             },
-            "scripts": {
-                "post-autoload-dump": [
-                    "NewsHour\\WPCoreThemeComponents\\Containers\\ContainerFactory::dumpAutoload"
-                ],
-                "tests": [
-                    "vendor/bin/phpunit --bootstrap vendor/autoload.php ./src/Tests",
-                    "phpcs --standard=psr12 ./src/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "NewsHour Core Wordpress theme components.",
             "support": {
-                "source": "https://github.com/newshour/wp-core-theme-components/tree/v1.0.14",
-                "issues": "https://github.com/newshour/wp-core-theme-components/issues"
+                "issues": "https://github.com/newshour/wp-core-theme-components/issues",
+                "source": "https://github.com/newshour/wp-core-theme-components/tree/v1.0.15"
             },
-            "time": "2022-01-05T14:59:05+00:00"
+            "time": "2022-01-06T15:56:55+00:00"
         },
         {
             "name": "oscarotero/env",
@@ -6075,12 +6137,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "926f263c0e50a30797761bbec10ea2dc665d63ba"
+                "reference": "cf076bc797a0051c51e958f3be7065d5c4c1b802"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/926f263c0e50a30797761bbec10ea2dc665d63ba",
-                "reference": "926f263c0e50a30797761bbec10ea2dc665d63ba",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/cf076bc797a0051c51e958f3be7065d5c4c1b802",
+                "reference": "cf076bc797a0051c51e958f3be7065d5c4c1b802",
                 "shasum": ""
             },
             "conflict": {
@@ -6294,7 +6356,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<10.2.6",
+                "pimcore/pimcore": "<10.2.7",
                 "pocketmine/pocketmine-mp": "<4.0.3",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -6312,7 +6374,7 @@
                 "pusher/pusher-php-server": "<2.2.1",
                 "pwweb/laravel-core": "<=0.3.6-beta",
                 "rainlab/debugbar-plugin": "<3.1",
-                "remdex/livehelperchat": "<=3.90",
+                "remdex/livehelperchat": "<3.91",
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": "<3.0.4",
                 "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
@@ -6501,7 +6563,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-05T15:16:14+00:00"
+            "time": "2022-01-05T21:13:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/web/app/themes/core/src/Http/Controllers/Posts/SingleController.php
+++ b/web/app/themes/core/src/Http/Controllers/Posts/SingleController.php
@@ -29,8 +29,9 @@ class SingleController extends Controller
 
         if ($post != null) {
             add_action('wp_head', function () use ($post, $metaFactory) {
+                // Output meta data into <head>. Here we are also adding a Twitter "label" card.
                 echo implode(PHP_EOL, [
-                    (string) $metaFactory->getPageMeta($post),
+                    (string) $metaFactory->getPageMeta($post)->getTwitterMeta()->addLabels(['Written By' => SITE_NAME]),
                     (string) $metaFactory->schemas()->getWebPageSchema($post)->asHtml()
                 ]);
             });


### PR DESCRIPTION
This PR removes the VCS repository entry. The components library is now available through packagist directly. Also included is an updated example on how to add Twitter "label" cards.